### PR TITLE
Azure Pipelines: remove ubuntu 18, mac 10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,18 +23,11 @@ strategy:
       imageName: 'ubuntu-20.04'
       the_name: 'Azure Pipelines'
 
-    ubuntu_18_04_gcc_8:
-      imageName: 'ubuntu-18.04'
-      the_name: 'Azure Pipelines'
-
     mac_12:
       imageName: 'macos-12'
       the_name: 'Azure Pipelines'
     mac_11:
       imageName: 'macos-11'
-      the_name: 'Azure Pipelines'
-    mac_10_15:
-      imageName: 'macos-10.15'
       the_name: 'Azure Pipelines'
 
     windows_2022:


### PR DESCRIPTION
Removes os images from builds which are deprecated.